### PR TITLE
:agg now returns a row for empty left when all grouped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+### `:agg` behaviour change (minor breaking)
+
+`:agg` with over all rows now always returns a row with default values instead of nil.
+
+e.g `[[:const] [:agg [] [:n count]]]` will return `[{:n 0}]` instead of `nil`.
+
+This is closer to SQL and will mean a constraint like `[[:from :a] [:agg [] [:n count]] [:check [= 1 :n]]]` will throw if there are no rows, instead of just if there are more than 1.
+
 ## 0.1.4
 
 - fixed no results when using `[:_ kw]` with indexed `:where` queries

--- a/doc/agg.md
+++ b/doc/agg.md
@@ -25,13 +25,31 @@ Say you have a table of maps representing customer orders, and you want to compu
 ({:customer-id 42, :average-spend 18.5M, :order-count 2, :total-spend 37.0M})
 ```
 
+Let's break down the shape of the `:agg` operator:
+
+`[:agg cols & agg-bindings]`
+
+The `cols` will be a vector of column names, so in the example above `[:customer-id]` is used so we will be aggregating 
+over rows grouped by their customer-id. You could have used `[:customer-id, :delivery-date]` or any combination of columns.
+
+The empty vector `[]` can be used to group over all rows.
+
+Each `agg-binding` is a vector tuple `[binding agg-expr]`, the `binding` is the name of the new column 
+you want the aggregated value to sit under, the `agg-expr` consists of an aggregation function (and any arguments).
+
+So for `[:total-spend [rel/sum :total]]` 
+    
+- `:total-spend` is the binding 
+- `rel/sum` is an aggregation function
+
+Aggregation functions are built-in, they are not normal functions unfortunately - this is necessary for materialized views to work.
+
+You may later be able to extend relic with user defined aggregations, but the tools for that are not final.
+
 See also: [aggregates](aggregates.md) for aggregate functions that you can use.
 
-## Spec
+## N.B Empty relations
 
-```clojure
-stmt = [:agg cols & bindings]
-cols = [& col]
-binding = [new-col agg-expr]
-agg-expr = agg-fn|[agg-fn & args]
-```
+If you are aggregating over all rows, `:agg` will always return a row, even if the input relation is empty.
+
+e.g you will get `{:count 0}` back (not `nil`) if you ask for a count of all rows and there are no rows.

--- a/src/com/wotbrew/relic/impl/dataflow.cljc
+++ b/src/com/wotbrew/relic/impl/dataflow.cljc
@@ -88,7 +88,10 @@
       row)
     (let [{:keys [error]} check
           error-fn (e/row-fn (or error "Check constraint violation"))]
-      (u/raise (error-fn row) {:check check, :row row, :relvar relvar}))))
+      (u/raise (error-fn row) {:com.wotbrew.relic/error :check-violation
+                               :check check,
+                               :row row,
+                               :relvar relvar}))))
 
 (defn- good-check [relvar check row]
   row)

--- a/test/com/wotbrew/relic/prop_test.cljc
+++ b/test/com/wotbrew/relic/prop_test.cljc
@@ -6,7 +6,8 @@
             [clojure.test.check :as tc]
             [com.wotbrew.relic.impl.util :as u]
             [clojure.set :as set]
-            [com.wotbrew.relic.impl.dataflow :as dataflow]))
+            [com.wotbrew.relic.impl.dataflow :as dataflow]
+            [com.wotbrew.relic.impl.relvar :as r]))
 
 (defn- available-mat-types [model]
   (cond->
@@ -104,7 +105,10 @@
     (let [db (-> {} (domuts muts) delete-all)
           graph (dataflow/gg db)
           nodemap (::dataflow/ids graph)
-          const? (fn [relvar] (boolean (seq (rel/q {} relvar))))]
+          unmat (fn [relvar] (if (= @#'dataflow/mat (r/head-operator relvar))
+                               (pop relvar)
+                               relvar))
+          const? (fn [relvar] (boolean (seq (rel/q {} (unmat relvar)))))]
       (if (const? q)
         true
         (and (empty? (rel/q db q))

--- a/test/com/wotbrew/relic_test.cljc
+++ b/test/com/wotbrew/relic_test.cljc
@@ -1388,7 +1388,6 @@
     (is (= {:a :a} (rel/row db :a [= :a [:_ :a]])))))
 
 (deftest empty-agg-default-test
-
   (is (= [{:n 0}] (rel/q {} [[:from :foo] [:agg [] [:n count]]])))
   (is (= [{:n 0}] (rel/q {} [[:from :foo] [:agg [] [:n [count false]]]])))
   (is (= [{:n 0}] (rel/q {} [[:from :foo] [:agg [] [:n [count true]]]])))
@@ -1399,9 +1398,11 @@
   (is (= [{:n false}] (rel/q {} [[:from :foo] [:agg [] [:n [rel/any :a]]]])))
   (is (= [{:n true}] (rel/q {} [[:from :foo] [:agg [] [:n [rel/not-any :a]]]])))
   (is (= [{:n #{}}] (rel/q {} [[:from :foo] [:agg [] [:n [rel/set-concat :a]]]])))
-  (is (= [{:n 0}] (rel/q {} [[:from :foo] [:agg [] [:n [rel/count-distinct :a]]]])))
+  (is (= [{:n 0}] (rel/q {} [[:from :foo] [:agg [] [:n [rel/count-distinct :a]]]]))))
 
-  )
+(deftest more-than-one-row-constraint-test
+  (is (= :check-violation (error-type #(rel/q {} [[:from :foo] [:agg [] [:n count]] [:check [= :n 1]]]))))
+  (is (= :check-violation (error-type #(rel/q {} [[:agg [] [:n count]] [:check [= :n 1]]])))))
 
 (comment
   (clojure.test/run-all-tests #"com\.wotbrew\.relic(.*)-test"))


### PR DESCRIPTION
`:agg` behaviour change (minor breaking)

`:agg` with over all rows now always returns a row with default values instead of nil.

e.g `[[:const] [:agg [] [:n count]]]` will return `[{:n 0}]` instead of `nil`.

This is closer to SQL and will mean a constraint like `[[:from :a] [:agg [] [:n count]] [:check [= 1 :n]]]` will throw if there are no rows, instead of just if there are more than 1.